### PR TITLE
添加 actuator 健康检查 & prometheus 指标暴露

### DIFF
--- a/langchat-auth/src/main/java/cn/tycoding/langchat/auth/config/SecurityConfig.java
+++ b/langchat-auth/src/main/java/cn/tycoding/langchat/auth/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package cn.tycoding.langchat.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/prometheus").authenticated() // 需要认证
+                        .anyRequest().permitAll() // 其他接口走Sa-Token
+                )
+                .httpBasic(withDefaults()); // 用 HTTP Basic 认证
+
+        http.csrf(AbstractHttpConfigurer::disable); // 禁用 CSRF（针对非浏览器客户端）
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.withDefaultPasswordEncoder()
+                .username("admin")
+                .password("admin")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+}

--- a/langchat-common/langchat-common-core/pom.xml
+++ b/langchat-common/langchat-common-core/pom.xml
@@ -83,12 +83,26 @@
             <version>${hutool.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/langchat-server/src/main/resources/application.yml
+++ b/langchat-server/src/main/resources/application.yml
@@ -25,12 +25,18 @@ spring:
     async:
       request-timeout: 3600000
 
+  # 自定义安全配置（如果不想用代码配置用户）
+  security:
+    user:
+      name: admin
+      password: admin
+
 # MybatisPlus配置
 mybatis-plus:
   mapper-locations: classpath:mapper/**/*.xml
   configuration:
     jdbc-type-for-null: null
-#    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+  #    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
   global-config:
     banner: false
 
@@ -44,3 +50,12 @@ logging:
       langchain4j: DEBUG
       ai4j:
         openai4j: DEBUG
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  health:
+    elasticsearch:
+      enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <snakeyaml.version>2.1</snakeyaml.version>
         <langchain4j.version>0.36.0</langchain4j.version>
         <sa-token.version>1.37.0</sa-token.version>
+        <micrometer.version>1.12.3</micrometer.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
1. 添加 spring actuator，暂时将 elasticsearch 端点禁用
2. 集成 micrometer 暴露 prometheus 指标
3. 集成 spring security 对 /actuator/prometheus 接口鉴权